### PR TITLE
[feature] Remove json serialization, max message size restrictions

### DIFF
--- a/lib/warehouse/analytics/message_batch.rb
+++ b/lib/warehouse/analytics/message_batch.rb
@@ -14,35 +14,20 @@ module Warehouse
       def initialize(max_message_count)
         @messages = []
         @max_message_count = max_message_count
-        @json_size = 0
       end
 
       def <<(message)
-        begin
-          message_json = Warehouse::Analytics::Transformer.transform(message).to_json
-        rescue StandardError => e
-          raise JSONGenerationError, "Serialization error: #{e}"
-        end
-
-        message_json_size = message_json.bytesize
-        if message_too_big?(message_json_size)
-          logger.error('a message exceeded the maximum allowed size')
-        else
-          @messages << message
-          @json_size += message_json_size + 1 # One byte for the comma
-        end
+        @messages << Warehouse::Analytics::Transformer.transform(message)
       end
 
       def full?
-        item_count_exhausted? || size_exhausted?
+        item_count_exhausted?
       end
 
       def clear
         @messages.clear
-        @json_size = 0
       end
 
-      def_delegators :@messages, :to_json
       def_delegators :@messages, :empty?
       def_delegators :@messages, :length
 
@@ -50,22 +35,6 @@ module Warehouse
 
       def item_count_exhausted?
         @messages.length >= @max_message_count
-      end
-
-      def message_too_big?(message_json_size)
-        message_json_size > Defaults::Message::MAX_BYTES
-      end
-
-      # We consider the max size here as just enough to leave room for one more
-      # message of the largest size possible. This is a shortcut that allows us
-      # to use a native Ruby `Queue` that doesn't allow peeking. The tradeoff
-      # here is that we might fit in less messages than possible into a batch.
-      #
-      # The alternative is to use our own `Queue` implementation that allows
-      # peeking, and to consider the next message size when calculating whether
-      # the message can be accomodated in this batch.
-      def size_exhausted?
-        @json_size >= (MAX_BYTES - Defaults::Message::MAX_BYTES)
       end
     end
   end

--- a/spec/warehouse/analytics/message_batch_spec.rb
+++ b/spec/warehouse/analytics/message_batch_spec.rb
@@ -10,14 +10,6 @@ module Warehouse
           subject << { 'a' => 'b' }
           expect(subject.length).to eq(1)
         end
-
-        it 'rejects messages that exceed the maximum allowed size' do
-          max_bytes = Defaults::Message::MAX_BYTES
-          message = { 'a' => 'b' * max_bytes }
-
-          subject << message
-          expect(subject.length).to eq(0)
-        end
       end
 
       describe '#full?' do
@@ -26,22 +18,6 @@ module Warehouse
           expect(subject.full?).to be(false)
 
           subject << { a: 'b' }
-          expect(subject.full?).to be(true)
-        end
-
-        it 'returns true once max size is almost exceeded' do
-          message = { a: 'b' * (Defaults::Message::MAX_BYTES - 10) }
-
-          message_size = message.to_json.bytesize
-
-          # Each message is under the individual limit
-          expect(message_size).to be < Defaults::Message::MAX_BYTES
-
-          # Size of the batch is over the limit
-          expect(50 * message_size).to be > Defaults::MessageBatch::MAX_BYTES
-
-          expect(subject.full?).to be(false)
-          50.times { subject << message }
           expect(subject.full?).to be(true)
         end
       end

--- a/spec/warehouse/analytics/worker_spec.rb
+++ b/spec/warehouse/analytics/worker_spec.rb
@@ -86,27 +86,6 @@ module Warehouse
 
           expect(queue).to be_empty
         end
-
-        it 'calls on_error for bad json' do
-          bad_obj = Object.new
-          def bad_obj.to_json(*_args)
-            raise "can't serialize to json"
-          end
-
-          on_error = proc {}
-          expect(on_error).to receive(:call).once.with(-1, /serialize to json/)
-
-          good_message = Requested::TRACK
-          bad_message = Requested::TRACK.merge({ 'bad_obj' => bad_obj })
-
-          queue = Queue.new
-          queue << good_message
-          queue << bad_message
-
-          worker = described_class.new(queue, :on_error => on_error)
-          worker.run
-          expect(queue).to be_empty
-        end
       end
 
       describe '#is_requesting?' do


### PR DESCRIPTION
## What

- Drops JSON serialization
- Drops Message byte size restrictions
- Drops Message batch byte size restrictions
- Removes all associated tests for those behaviors
