### PR TITLE
Adjust snake_case to remove extra underscores

### DIFF
--- a/lib/warehouse/analytics/transformer.rb
+++ b/lib/warehouse/analytics/transformer.rb
@@ -53,6 +53,7 @@ module Warehouse
             .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')   # Insert _ between capital letter preceding lower case letter (ignores the start of the word)
             .gsub(/([a-z])([A-Z])/,'\1_\2')         # Insert _ between lower case letter preceding a capital letter
             .tr("- ", "_")                          # Convert hyphens - and spaces to underscore
+            .squeeze("_")                           # Remove any extra underscores next to each other __ to _
             .downcase                               # Convert all capital letters to lower case
         end
 

--- a/spec/warehouse/analytics/transformer_spec.rb
+++ b/spec/warehouse/analytics/transformer_spec.rb
@@ -109,12 +109,12 @@ module Warehouse
           }.stringify_keys)
         end
 
-        it 'snake_cases event name with : and /' do
+        it 'snake_cases event name with a space, :, and /' do
           message = {
-            event: "Test:Event/GreatName"
+            event: "Test: Event/GreatName"
           }
           expect(Transformer.transform(message)).to eq({
-            event_text: "Test:Event/GreatName",
+            event_text: "Test: Event/GreatName",
             event: "test_event_great_name"
           }.stringify_keys)
         end


### PR DESCRIPTION
## Why?

We were running into issues where table names weren't lining up to event slug names, because of multiple underscores. 

## What?

- Adjust `snake_case` method to remove extra neighboring underscores


`Test: Thing` should be `test_thing` not `test__thing`