### PR TITLE
Groups events in batch by model for bulk-insertion

### DIFF
--- a/lib/warehouse/analytics/message_batch.rb
+++ b/lib/warehouse/analytics/message_batch.rb
@@ -29,6 +29,7 @@ module Warehouse
       def_delegators :@messages, :empty?
       def_delegators :@messages, :length
       def_delegators :@messages, :each
+      def_delegators :@messages, :group_by
 
       private
 

--- a/spec/warehouse/analytics/transport_spec.rb
+++ b/spec/warehouse/analytics/transport_spec.rb
@@ -46,7 +46,11 @@ module Warehouse
               .with({ 'event' => 'on_demand_practice_learn_more_clicked' })
               .and_call_original
             expect(Tracking::Warehouse::OnDemandPracticeLearnMoreClicked).to receive(:import)
-              .with([an_instance_of(Tracking::Warehouse::OnDemandPracticeLearnMoreClicked)])
+              .with(
+                ['event'],
+                [an_instance_of(Tracking::Warehouse::OnDemandPracticeLearnMoreClicked)],
+                validate: false
+              )
               .and_return(double(failed_instances: []))
             described_class.new(options).send(batch)
           end


### PR DESCRIPTION
## Why?

Resolves https://seismic.atlassian.net/browse/LRE-946

We want to group events by table so we can bulk-insert them with ActiveRecord-Import.