### PR TITLE
Adds configurable metrics object to hook into instrumentation

### DIFF
--- a/lib/warehouse/analytics/null_metrics.rb
+++ b/lib/warehouse/analytics/null_metrics.rb
@@ -1,0 +1,16 @@
+# A metrics interface which does not record metrics
+module Warehouse
+  class Analytics
+    class NullMetrics
+      def increment(_key, _value)
+      end
+
+      def gauge(_key, _value)
+      end
+
+      def time(_key)
+        yield
+      end
+    end
+  end
+end

--- a/lib/warehouse/analytics/transport.rb
+++ b/lib/warehouse/analytics/transport.rb
@@ -39,6 +39,8 @@ module Warehouse
                 logger.warn("Failed to insert #{result.failed_instances.length} warehouse events with name '#{event_name}'")
                 metrics.increment("warehouse_analytics.transport.failures", result.failed_instances.length)
               end
+            else
+              logger.warn("Receieved an event (#{event_name}) without a matching key in the event_models hash")
             end
           end
         end

--- a/lib/warehouse/analytics/transport.rb
+++ b/lib/warehouse/analytics/transport.rb
@@ -34,7 +34,6 @@ module Warehouse
                 event_model.new(message)
               end
               result = event_model.import(column_names, records, :validate => false)
-              metrics.increment("warehouse_analytics.transport.inserts", result.num_inserts)
               if result.failed_instances.present?
                 logger.warn("Failed to insert #{result.failed_instances.length} warehouse events with name '#{event_name}'")
                 metrics.increment("warehouse_analytics.transport.failures", result.failed_instances.length)

--- a/lib/warehouse/analytics/transport.rb
+++ b/lib/warehouse/analytics/transport.rb
@@ -23,6 +23,7 @@ module Warehouse
         metrics.gauge("warehouse_analytics.batch.size", batch.length)
         metrics.time("warehouse_analytics.transport.latency") do
           batches_by_model = batch.group_by { |message| message['event_text'] }
+          metrics.gauge("warehouse_analytics.batch.model_count", batches_by_model.length)
           batches_by_model.each do |event_name, messages|
             event_model = @event_models[event_name]
 


### PR DESCRIPTION
## Why?

We'll need visibility into how warehouse-analytics is performing in production, so we'd like to hook it up to our instrumentation provider. We'd like to observe the following data points:

- queue depth over time
- batch size over time
- worker latency
- count of events successfully written
- count of events we failed to write

## What

This introduces a `metrics` object which defaults to a no-op `NullMetrics` but which can be replaced at configuration time with an object that matches a simple interface, implementing:

- `increment(key, count)` for recording the number of times something happened
- `gauge(key, reading)` for recording the point-in-time value of something
- `time(key, &block)` for recording how long a block took to execute

## Does it work?

Confirmed working when I pulled this branch [into a review app!](http://dev.lessonly-pr-11177.lessonlybeta.com/people)

<img width="1526" alt="Screen Shot 2022-05-18 at 1 35 19 PM" src="https://user-images.githubusercontent.com/664341/169107322-84b4ce3d-7754-4a7a-98ae-632b5f5a5b30.png">
